### PR TITLE
Add ignore list support to parser

### DIFF
--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -7,7 +7,13 @@
       "request": "launch",
       "mainClass": "Main",
       "projectName": "antlr-rust-project_789395e9",
-      "args": ["/home/socub/U/tesis/rust_repos/rust_2/src/tools/rust-analyzer/crates/parser/test_data/lexer/ok/", "print", "/home/socub/U/tesis/rust_repos/rust_2/src/tools/rust-analyzer/crates/parser/test_data/lexer/ok/raw_strings.rs"],
+      "args": [
+        "/home/socub/U/tesis/rust_repos/rust_2/src/tools/rust-analyzer/crates/parser/test_data/lexer/ok/",
+        "print",
+        "/home/socub/U/tesis/rust_repos/rust_2/src/tools/rust-analyzer/crates/parser/test_data/lexer/ok/raw_strings.rs",
+        "${config:to_ignore}"
+      ],
+      "to_ignore": "to_ignore.txt",
       "preLaunchTask": "",
     }
   ]


### PR DESCRIPTION
## Summary
- add `to_ignore` setting in VS Code launch configuration
- track ignored files using new `IgnoreData` helper in Java
- output list of parsed files
- skip parsing files listed in the ignore file

## Testing
- `javac @sources.txt` *(fails: not a statement in generated/RustLexer.java)*
- `javac src/Main.java` *(fails: cannot find symbol ParseTree - missing ANTLR deps)*